### PR TITLE
{README,tc}: fix misaligned packet access error thrown by BPF verifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ Load it with `tc` commands:
   tc filter add dev "${IFACE}" ingress chain 1 bpf object-file tcp_in_udp_tc.o section tc direct-action
   ```
 
+On layer 3 interfaces, use the ELF section called `tc_l3`.
+
 Multiple u32 filters can be used to have more than one port traffic sent to the
 BPF program.
 


### PR DESCRIPTION
The BPF verifier rejects running the programme due to misaligned packet access when attempting to load the programme on certain interfaces such as a DSA user interface. Split the layer 3 interface support out to a separate ELF section to address this.

Fixes: 58342d35a6f1 ("tc: support layer 3 interfaces")